### PR TITLE
Refactor Segue Code (EditNote)

### DIFF
--- a/CleanNoteCore/CleanNoteCore/Code/StoryboardCoordinator.swift
+++ b/CleanNoteCore/CleanNoteCore/Code/StoryboardCoordinator.swift
@@ -1,0 +1,9 @@
+//
+//  StoryboardCoordinator.swift
+//  CleanNoteCore
+//
+//  Created by Paul Stringer on 26/09/2016.
+//  Copyright © 2016 cutting.io. All rights reserved.
+//
+
+import Foundation

--- a/CleanNoteiOS/CleanNoteiOS.xcodeproj/project.pbxproj
+++ b/CleanNoteiOS/CleanNoteiOS.xcodeproj/project.pbxproj
@@ -7,7 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8C089EA51D9EC06C00077828 /* StoryboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C089EA41D9EC06C00077828 /* StoryboardViewController.swift */; };
+		8C95575F1DB33D1000E7FBE7 /* EditorSegueConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C95575E1DB33D1000E7FBE7 /* EditorSegueConfiguration.swift */; };
 		8CC323B91D99755400CF1557 /* TestableAlertHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC323B81D99755400CF1557 /* TestableAlertHelper.swift */; };
+		8CC323C51D998CDF00CF1557 /* StoryboardSegueCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC323C41D998CDF00CF1557 /* StoryboardSegueCoordinator.swift */; };
 		C8296D4A1D665FE800E5DA44 /* AlertHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8296D491D665FE800E5DA44 /* AlertHelper.swift */; };
 		C83BAD4A1D48E9CA00180193 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C83BAD481D48E9CA00180193 /* Main.storyboard */; };
 		C83BAD4C1D48E9CA00180193 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C83BAD4B1D48E9CA00180193 /* Assets.xcassets */; };
@@ -73,7 +76,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		8C089EA41D9EC06C00077828 /* StoryboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StoryboardViewController.swift; path = CleanNoteiOS/Code/StoryboardViewController.swift; sourceTree = "<group>"; };
+		8C95575E1DB33D1000E7FBE7 /* EditorSegueConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EditorSegueConfiguration.swift; path = CleanNoteiOS/Code/EditorSegueConfiguration.swift; sourceTree = "<group>"; };
 		8CC323B81D99755400CF1557 /* TestableAlertHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestableAlertHelper.swift; sourceTree = "<group>"; };
+		8CC323C41D998CDF00CF1557 /* StoryboardSegueCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StoryboardSegueCoordinator.swift; path = CleanNoteiOS/Code/StoryboardSegueCoordinator.swift; sourceTree = "<group>"; };
 		C8296D491D665FE800E5DA44 /* AlertHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertHelper.swift; sourceTree = "<group>"; };
 		C83BAD411D48E9CA00180193 /* CleanNote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CleanNote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C83BAD491D48E9CA00180193 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -115,6 +121,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8C9557601DB33DB400E7FBE7 /* Flow */ = {
+			isa = PBXGroup;
+			children = (
+				8C089EA41D9EC06C00077828 /* StoryboardViewController.swift */,
+				8CC323C41D998CDF00CF1557 /* StoryboardSegueCoordinator.swift */,
+				8C95575E1DB33D1000E7FBE7 /* EditorSegueConfiguration.swift */,
+			);
+			name = Flow;
+			sourceTree = "<group>";
+		};
 		C8296D4C1D6660E500E5DA44 /* Common */ = {
 			isa = PBXGroup;
 			children = (
@@ -130,6 +146,7 @@
 			children = (
 				C8DF78E11D490A1B0070D75A /* Boilerplate */,
 				C8DF78E21D490A3D0070D75A /* UI */,
+				8C9557601DB33DB400E7FBE7 /* Flow */,
 				C8DF78B51D4905770070D75A /* Modules */,
 				C8296D4C1D6660E500E5DA44 /* Common */,
 				C8DF78C21D4905810070D75A /* Mocks */,
@@ -364,8 +381,11 @@
 				C8DF78C01D4905770070D75A /* ListWireframe.swift in Sources */,
 				C8DF78BC1D4905770070D75A /* AppDelegate.swift in Sources */,
 				C8DF78C11D4905770070D75A /* RootWireframe.swift in Sources */,
+				8C089EA51D9EC06C00077828 /* StoryboardViewController.swift in Sources */,
 				C8DF78BD1D4905770070D75A /* EditorViewController.swift in Sources */,
+				8C95575F1DB33D1000E7FBE7 /* EditorSegueConfiguration.swift in Sources */,
 				C8296D4A1D665FE800E5DA44 /* AlertHelper.swift in Sources */,
+				8CC323C51D998CDF00CF1557 /* StoryboardSegueCoordinator.swift in Sources */,
 				C8DF78BF1D4905770070D75A /* ListViewController.swift in Sources */,
 				C8DF78BE1D4905770070D75A /* EditorWireframe.swift in Sources */,
 			);

--- a/CleanNoteiOS/CleanNoteiOS/Code/EditorSegueConfiguration.swift
+++ b/CleanNoteiOS/CleanNoteiOS/Code/EditorSegueConfiguration.swift
@@ -1,0 +1,36 @@
+import UIKit
+import CleanNoteCore
+
+extension EditorViewController: Segueable {
+    func accept(visitor: StoryboardViewControllerVisitor){
+        visitor.process(self)
+    }
+}
+
+extension StoryboardSegueCoordinator {
+    
+    internal func process(_ viewController: EditorViewController) {
+        guard let source = segue.source as? ListViewController else { return }
+        let noteID = noteIDFrom(object: sender) ?? noteIDForSelectedRowIn(tableView: source.tableView)!
+        source.editorWireframe.configure(editorViewController: viewController, noteID: noteID)
+    }
+    
+    fileprivate func noteIDFrom(object: Any?) -> NoteID? {
+        guard let noteIDWrapperObject = object as? NoteIDWrapperObject else { return nil }
+        return noteIDWrapperObject.id
+    }
+    
+    private func noteIDForSelectedRowIn(tableView :UITableView) -> NoteID? {
+        let indexPath = tableView.indexPathForSelectedRow
+        guard let selectedRow = indexPath?.row else { return nil }
+        return noteIDFor(row: selectedRow)
+    }
+    
+    fileprivate func noteIDFor(row: Int) -> NoteID? {
+        guard let source = segue.source as? ListViewController else { return nil }
+        guard let listViewNote = source.list?.notes[row] else { return nil }
+        return listViewNote.id
+    }
+    
+}
+

--- a/CleanNoteiOS/CleanNoteiOS/Code/EditorViewController.swift
+++ b/CleanNoteiOS/CleanNoteiOS/Code/EditorViewController.swift
@@ -11,9 +11,13 @@ class EditorViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    interactor.fetchText()
     textView.becomeFirstResponder()
   }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        interactor.fetchText()
+    }
+    
 }
 
 extension EditorViewController: EditorInterface {

--- a/CleanNoteiOS/CleanNoteiOS/Code/ListViewController.swift
+++ b/CleanNoteiOS/CleanNoteiOS/Code/ListViewController.swift
@@ -11,7 +11,7 @@ class NoteIDWrapperObject: NSObject {
   }
 }
 
-class ListViewController: UIViewController {
+class ListViewController: StoryboardViewController {
   var interactor: ListInteractorInput!
   var editorWireframe: EditorWireframe!
   var list: ListViewList?
@@ -22,24 +22,6 @@ class ListViewController: UIViewController {
     interactor.fetchNotesAndSelect(noteID: nil)
   }
 
-  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    guard EditNoteSegueIdentifier == segue.identifier else { return }
-    let editorViewController = segue.destination as! EditorViewController
-    let noteID = noteIDFrom(object: sender) ?? noteIDForSelectedRow()!
-    editorWireframe.configure(editorViewController: editorViewController, noteID: noteID)
-  }
-
-  fileprivate func noteIDFrom(object: Any?) -> NoteID? {
-    guard let noteIDWrapperObject = object as? NoteIDWrapperObject else { return nil }
-    return noteIDWrapperObject.id
-  }
-
-  private func noteIDForSelectedRow() -> NoteID? {
-    let indexPath = tableView.indexPathForSelectedRow
-    guard let selectedRow = indexPath?.row else { return nil }
-    return noteIDFor(row: selectedRow)
-  }
-
   fileprivate func noteIDFor(row: Int) -> NoteID? {
     guard let listViewNote = list?.notes[row] else { return nil }
     return listViewNote.id
@@ -48,6 +30,7 @@ class ListViewController: UIViewController {
   @IBAction func addNote(_ sender: AnyObject) {
     interactor.makeNote()
   }
+    
 }
 
 extension ListViewController: ListInterface {

--- a/CleanNoteiOS/CleanNoteiOS/Code/StoryboardSegueCoordinator.swift
+++ b/CleanNoteiOS/CleanNoteiOS/Code/StoryboardSegueCoordinator.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+protocol StoryboardViewControllerVisitor {
+    func process(_ viewController: EditorViewController)
+}
+
+protocol Segueable {
+    func accept(visitor: StoryboardViewControllerVisitor)
+}
+
+struct StoryboardSegueCoordinator: StoryboardViewControllerVisitor {
+    
+    let segue: UIStoryboardSegue
+    let sender: Any?
+    
+    func prepare() {
+        guard let destination = segue.destination as? Segueable else {return}
+        destination.accept(visitor: self)
+    }
+    
+}
+
+
+

--- a/CleanNoteiOS/CleanNoteiOS/Code/StoryboardViewController.swift
+++ b/CleanNoteiOS/CleanNoteiOS/Code/StoryboardViewController.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+class StoryboardViewController: UIViewController {
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+    
+        let coordinator = StoryboardSegueCoordinator(segue: segue, sender: sender)
+        
+        coordinator.prepare()
+        
+    }
+    
+}


### PR DESCRIPTION
In preparation for Swift Summit and following on previous 'Architecture' discussions this is a series of PR's to attempt to improve handling of Storyboards and Segues and to extend them cleanly into a clean architecture. I wanted to see if I could do this in a Viper application as I've generally been unhappy with the 'Wireframe' 'Router' approach which tends to demote Storyboards as the configuration of flow for an App.

The main goal of this work is to 
- Promote Storyboards to be the  central 'configuration' of flow and transitions between View Controllers.
- Create a more generalised pattern for handling Storyboard Segues
- Move outside of ViewControllers specific code that prepares ViewControllers e.g. Generalise the Prepare(for segue) method.
- Lower reliance on stringly-typed Segue Identifiers
- Remove requirement for forced casts of Destination View Controllers
- Generalise a solution for passing data between source and destination view controllers

This PR introduces the Dual Dispatch mechanism found in the Visitor Pattern a reasonable improvement can be made through it's introduction to generalising parts the prepareForSegue.

It seems a reasonable pattern to start with to begin the process of extending destination View Controllers with configuration whilst keeping source View Controllers closed to internal changes to be able to do so. 

This PR makes three specific changes.
- Introduces the dual dispatch 'Visitor' mechanism for handling 'prepareForSegue'
- Makes the EditorViewController 'Visitable'
- Moves Configuration from EditorWireframe to a StoryboardCoordinator (the Visitor)

Further PR's build on these changes to complete the refactoring. Interested to see what you think. I'm hoping to be able to come up with a repeatable pattern that potentially might even be built as a library. I'm totally open to any other ideas that this might trigger in how to do this.
